### PR TITLE
allow pfx files to be used instead of cert and key

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,15 @@ function createDeviceTokens(token) {
 
 module.exports = function(message, options, callback){
   var defaultOptions = {
-    cert: 'cert.pem',
-    key: 'key.pem',
     fastMode: true,
     production: true,
     connectionTimeout: 1000
   };
+
+  if (!options.pfx) {
+    Object.assign(defaultOptions, { cert: 'cert.pem', key: 'key.pem' })
+  }
+
   options = _.defaults(options, defaultOptions);
   callback = callback || _.noop;
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(message, options, callback){
   };
 
   if (!options.pfx) {
-    Object.assign(defaultOptions, { cert: 'cert.pem', key: 'key.pem' })
+    _.assign(defaultOptions, { cert: 'cert.pem', key: 'key.pem' })
   }
 
   options = _.defaults(options, defaultOptions);

--- a/test.js
+++ b/test.js
@@ -55,6 +55,48 @@ describe('call node-apn with correct properties', function() {
 
       apnTest(null, options);
     });
+
+    it('no key or cert properties if only pfx is provided', function(done) {
+      var localOptions = {
+        pfx: './cert.p12',
+        token: options.token
+      }
+
+      apnStub.Connection = function(opts) {
+        assert.strictEqual(opts.key, undefined)
+        assert.strictEqual(opts.cert, undefined)
+
+        done()
+
+        return {
+          pushNotification: _.noop
+        };
+      }
+
+      apnTest(null, localOptions)
+    })
+
+    it('should have key and cert props if provided with pfx', function(done) {
+      var localOptions = {
+        pfx: './cert.p12',
+        key: './myKey.pem',
+        cert: './mycert.pem',
+        token: options.token
+      }
+
+      apnStub.Connection = function(opts) {
+        assert.strictEqual(opts.key, localOptions.key)
+        assert.strictEqual(opts.cert, localOptions.cert)
+
+        done()
+
+        return {
+          pushNotification: _.noop
+        };
+      }
+
+      apnTest(null, localOptions)
+    })
   });
 
   describe('apn.Device', function() {


### PR DESCRIPTION
when a pfx file is provided apn will ignore the cert and key